### PR TITLE
Add wrappers for *xattr calls

### DIFF
--- a/communicate.h
+++ b/communicate.h
@@ -139,14 +139,27 @@
    enabled any more, but used to be in libtricks.
 */
 
-enum {chown_func,
-        /*2*/  chmod_func,
-        /*3*/  mknod_func,
-               stat_func,
-        /*5*/  unlink_func,
-               debugdata_func,
-               reqoptions_func,
+enum {chown_func = 0,
+               chmod_func = 1,
+               mknod_func = 2,
+               stat_func = 3,
+               unlink_func = 4,
+               debugdata_func = 5,
+               reqoptions_func = 6,
+               listxattr_func = 7,
+               getxattr_func = 8,
+               setxattr_func = 9,
+               removexattr_func = 10,
                last_func};
+
+typedef struct {
+  int func;
+  const char *name;
+  char *value;
+  size_t size;
+  int flags;
+  int rc;
+} xattr_args;
 
 #include "message.h"
 
@@ -161,6 +174,11 @@ extern void send_fakem(const struct fake_msg *buf);
 extern void send_get_stat(struct stat *buf);
 #else
 extern void send_get_stat(struct stat *buf,int ver);
+#endif
+#ifndef STUPID_ALPHA_HACK
+extern void send_get_xattr(struct stat *st, xattr_args *xattr);
+#else
+extern void send_get_xattr(struct stat *st, xattr_args *xattr, int ver);
 #endif
 extern void cpyfakefake (struct fakestat *b1, const struct fakestat *b2);
 #ifndef STUPID_ALPHA_HACK
@@ -189,9 +207,11 @@ extern void unlock_comm_sd(void);
 #ifndef STUPID_ALPHA_HACK
 extern void send_stat64(const struct stat64 *st, func_id_t f);
 extern void send_get_stat64(struct stat64 *buf);
+extern void send_get_xattr64(struct stat64 *st, xattr_args *xattr);
 #else
 extern void send_stat64(const struct stat64 *st, func_id_t f, int ver);
 extern void send_get_stat64(struct stat64 *buf, int ver);
+extern void send_get_xattr64(struct stat64 *st, xattr_args *xattr, int ver);
 #endif
 extern void stat64from32(struct stat64 *s64, const struct stat *s32);
 extern void stat32from64(struct stat *s32, const struct stat64 *s64);

--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ AC_SUBST(signal)
 dnl Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_STDC
-AC_CHECK_HEADERS(fcntl.h unistd.h features.h sys/feature_tests.h pthread.h stdint.h inttypes.h grp.h endian.h sys/sysmacros.h sys/socket.h sys/acl.h fts.h)
+AC_CHECK_HEADERS(fcntl.h unistd.h features.h sys/feature_tests.h pthread.h stdint.h inttypes.h grp.h endian.h sys/sysmacros.h sys/socket.h sys/acl.h sys/capability.h sys/xattr.h fts.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: fakeroot
 Section: utils
 Priority: optional
-Build-Depends: sharutils, gcc-multilib [amd64 i386 kfreebsd-amd64 powerpc s390 sparc], lib64c-dev [i386 powerpc s390 sparc], lib32c-dev [amd64 kfreebsd-amd64 ppc64], libacl1-dev
+Build-Depends: sharutils, gcc-multilib [amd64 i386 kfreebsd-amd64 powerpc s390 sparc], lib64c-dev [i386 powerpc s390 sparc], lib32c-dev [amd64 kfreebsd-amd64 ppc64], libacl1-dev, libcap-dev [amd64 i386], libcap2-bin [amd64 i386]
 Maintainer: Clint Adams <clint@debian.org>
 Standards-Version: 3.9.3
 Vcs-Git: git://git.debian.org/git/users/clint/fakeroot.git

--- a/faked.c
+++ b/faked.c
@@ -104,6 +104,9 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <sys/types.h>
+#ifdef HAVE_SYS_XATTR_H
+#include <sys/xattr.h>
+#endif
 #include <fcntl.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -150,6 +153,10 @@ void process_chmod(struct fake_msg *buf);
 void process_mknod(struct fake_msg *buf);
 void process_stat(struct fake_msg *buf);
 void process_unlink(struct fake_msg *buf);
+void process_listxattr(struct fake_msg *buf);
+void process_setxattr(struct fake_msg *buf);
+void process_getxattr(struct fake_msg *buf);
+void process_removexattr(struct fake_msg *buf);
 
 #ifdef FAKEROOT_FAKENET
 static int get_fakem(struct fake_msg *buf);
@@ -162,6 +169,12 @@ process_func func_arr[]={process_chown,
 			 process_mknod,
 			 process_stat,
 			 process_unlink,
+			 NULL, /* debugdata */
+			 NULL, /* reqoptions */
+			 process_listxattr,
+			 process_getxattr,
+			 process_setxattr,
+			 process_removexattr,
 			 };
 
 unsigned int highest_funcid = sizeof(func_arr)/sizeof(func_arr[0]);
@@ -190,12 +203,90 @@ static void fail(const char *msg)
 }
 #endif
 
+struct xattr_node_s;
+typedef struct xattr_node_s {
+  struct xattr_node_s *next;
+  char                *key;
+  char                *value;
+  size_t              value_size;
+} xattr_node_t;
+
 struct data_node_s;
 typedef struct data_node_s {
   struct data_node_s *next;
   struct fakestat     buf;
   uint32_t            remote;
+  xattr_node_t       *xattr;
 } data_node_t;
+
+static xattr_node_t *xattr_find(xattr_node_t *node, char *key)
+{
+  while (node) {
+    if (node->key && (!strcmp(node->key, key)))
+      break;
+    node = node->next;
+  }
+  return node;
+}
+
+static int xattr_erase(xattr_node_t **head, char *key)
+{
+  xattr_node_t *cur_node, *prev_node = NULL;
+
+  for (cur_node = *head; cur_node; prev_node = cur_node, cur_node = cur_node->next) {
+    if (cur_node->key && (!strcmp(cur_node->key, key))) {
+      if (prev_node == NULL) {
+        *head = cur_node->next;
+      } else {
+        prev_node->next = cur_node->next;
+      }
+      free(cur_node->key);
+      if (cur_node->value)
+        free(cur_node->value);
+      free(cur_node);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int xattr_clear(xattr_node_t **head)
+{
+  xattr_node_t *cur_node, *next_node;
+  cur_node = *head;
+  *head = NULL;
+  while (cur_node) {
+    next_node = cur_node->next;
+    if (cur_node->key)
+      free(cur_node->key);
+    if (cur_node->value)
+      free(cur_node->value);
+    free(cur_node);
+    cur_node = next_node;
+  }
+  return 0;
+}
+
+static xattr_node_t *xattr_insert(xattr_node_t **head)
+{
+  xattr_node_t *new_node;
+  new_node = calloc(1, sizeof(xattr_node_t));
+  new_node->next = *head;
+  *head = new_node;
+  return new_node;
+}
+
+static void xattr_fill(xattr_node_t *node, char *key, char *value, size_t value_size)
+{
+  if (node->key)
+    free(node->key);
+  node->key = strdup(key);
+  if (node->value)
+    free(node->value);
+  node->value = malloc(value_size);
+  memcpy(node->value, value, value_size);
+  node->value_size = value_size;
+}
 
 #define data_node_get(n)   ((struct fakestat *) &(n)->buf)
 
@@ -247,6 +338,7 @@ static void data_insert(const struct fakestat *buf,
   }
 
   memcpy(&n->buf, buf, sizeof (struct fakestat));
+  n->xattr = NULL;
   n->remote = (uint32_t) remote;
 }
 
@@ -266,6 +358,7 @@ static data_node_t *data_erase(data_node_t *pos)
   else
     prev->next = next;
 
+  xattr_clear(&n->xattr);
   free(n);
 
   return next;
@@ -361,6 +454,9 @@ static void faked_send_fakem(const struct fake_msg *buf)
   fm.st.mode = htonl(buf->st.mode);
   fm.st.nlink = htonl(buf->st.nlink);
   fm.remote = htonl(buf->remote);
+  fm.xattr.buffersize = htonl(buf->xattr.buffersize);
+  fm.xattr.flags_rc = htonl(buf->xattr.flags_rc);
+  memcpy(fm.xattr.buf, buf->xattr.buf, MAX_IPC_BUFFER_SIZE);
 
   while (1) {
     ssize_t len;
@@ -779,6 +875,169 @@ void process_unlink(struct fake_msg *buf){
   }
 }
 
+void process_listxattr(struct fake_msg *buf)
+{
+  data_node_t *i;
+  xattr_node_t *x = NULL;
+
+  buf->xattr.flags_rc = 0;
+  i = data_find(&buf->st, buf->remote);
+  if(debug){
+    fprintf(stderr,"FAKEROOT: process listxattr\n");
+  }
+  if (i != data_end()) {
+    x = i->xattr;
+  }
+  if (!x) {
+    if (debug) {
+      fprintf(stderr,"FAKEROOT:    (previously unknown)\n");
+    }
+    buf->xattr.buffersize = 0;
+  } else {
+    int bsize = 0;
+    while (x) {
+      int keysize = strlen(x->key);
+      if ((bsize + keysize + 1) > MAX_IPC_BUFFER_SIZE)
+      {
+        buf->xattr.flags_rc = ERANGE;
+        break;
+      }
+      strcpy(&buf->xattr.buf[bsize], x->key);
+      bsize += keysize + 1;
+      x = x->next;
+    }
+    buf->xattr.buffersize = bsize;
+    if(debug) {
+      fprintf(stderr,"FAKEROOT: (previously known): xattr=%s\n", buf->xattr.buf);
+    }
+  }
+  faked_send_fakem(buf);
+}
+
+void process_setxattr(struct fake_msg *buf)
+{
+  data_node_t *i;
+  xattr_node_t *x = NULL;
+  xattr_node_t **x_ref = NULL;
+  xattr_node_t *new_node = NULL;
+  struct fakestat st;
+  char *value = NULL;
+  int key_size, value_size;
+  int flags = buf->xattr.flags_rc;
+
+  buf->xattr.flags_rc = 0;
+  /* Need some more bounds checking */
+  key_size = strlen(buf->xattr.buf);
+  value = &buf->xattr.buf[key_size + 1];
+  value_size = buf->xattr.buffersize - key_size - 1;
+
+  i = data_find(&buf->st, buf->remote);
+  if(debug){
+    fprintf(stderr,"FAKEROOT: process setxattr key = %s\n", buf->xattr.buf);
+  }
+  if (i == data_end()) {
+    if (debug) {
+      fprintf(stderr,"FAKEROOT:    (previously unknown)\n");
+    }
+    st=buf->st;
+    /* We pretend that unknown files are owned
+       by root.root, so we have to maintain that pretense when the
+       caller asks to leave an id unchanged. */
+    if ((uint32_t)st.uid == (uint32_t)-1)
+       st.uid = 0;
+    if ((uint32_t)st.gid == (uint32_t)-1)
+       st.gid = 0;
+    insert_or_overwrite(&st, buf->remote);
+    i = data_find(&buf->st, buf->remote);
+  }
+  x = xattr_find(i->xattr, buf->xattr.buf);
+  if (x) {
+    if (flags == XATTR_CREATE) {
+      buf->xattr.flags_rc = EEXIST;
+      if (debug) {
+        fprintf(stderr,"FAKEROOT:    Already exists\n");
+      }
+    } else {
+      xattr_fill(x, buf->xattr.buf, value, value_size);
+      if (debug) {
+        fprintf(stderr,"FAKEROOT:    Replaced\n");
+      }
+    }
+  } else {
+    if (flags == XATTR_REPLACE) {
+      buf->xattr.flags_rc = ENODATA;
+      if (debug) {
+        fprintf(stderr,"FAKEROOT:    Replace requested but no previous entry found\n");
+      }
+    } else {
+      x = xattr_insert(&i->xattr);
+      xattr_fill(x, buf->xattr.buf, value, value_size);
+      if (debug) {
+        fprintf(stderr,"FAKEROOT:    Inserted\n");
+      }
+    }
+  }
+  buf->xattr.buffersize = 0;
+  faked_send_fakem(buf);
+}
+
+void process_getxattr(struct fake_msg *buf)
+{
+  data_node_t *i;
+  xattr_node_t *x = NULL;
+
+  buf->xattr.flags_rc = ENODATA;
+  i = data_find(&buf->st, buf->remote);
+  if(debug){
+    fprintf(stderr,"FAKEROOT: process getxattr key = %s\n", buf->xattr.buf);
+  }
+  if (i != data_end()) {
+    x = xattr_find(i->xattr, buf->xattr.buf);
+  }
+  if (!x) {
+    if (debug) {
+      fprintf(stderr,"FAKEROOT:    (previously unknown)\n");
+    }
+    buf->xattr.buffersize = 0;
+  } else {
+    if (debug) {
+      fprintf(stderr,"FAKEROOT: (previously known): %s\n", x->value);
+    }
+    buf->xattr.buffersize = x->value_size;
+    memcpy(buf->xattr.buf, x->value, x->value_size);
+    buf->xattr.flags_rc = 0;
+  }
+  faked_send_fakem(buf);
+}
+
+void process_removexattr(struct fake_msg *buf)
+{
+  data_node_t *i;
+  xattr_node_t *x = NULL;
+
+  buf->xattr.flags_rc = ENODATA;
+  i = data_find(&buf->st, buf->remote);
+  if(debug){
+    fprintf(stderr,"FAKEROOT: process removexattr key = %s\n", buf->xattr.buf);
+  }
+  if (i != data_end()) {
+    x = xattr_find(i->xattr, buf->xattr.buf);
+  }
+  if (!x) {
+    if (debug) {
+      fprintf(stderr,"FAKEROOT:    (previously unknown)\n");
+    }
+  } else {
+    if (debug) {
+      fprintf(stderr,"FAKEROOT: (previously known): %s\n", x->value);
+    }
+    xattr_erase(&i->xattr, buf->xattr.buf);
+    buf->xattr.flags_rc = 0;
+  }
+  buf->xattr.buffersize = 0;
+  faked_send_fakem(buf);
+}
+
 void debugdata(int dummy UNUSED){
   int stored_errno = errno;
   data_node_t *i;
@@ -1022,6 +1281,8 @@ static int get_fakem(struct fake_msg *buf)
   buf->st.mode = ntohl(buf->st.mode);
   buf->st.nlink = ntohl(buf->st.nlink);
   buf->remote = ntohl(buf->remote);
+  buf->xattr.buffersize = ntohl(buf->xattr.buffersize);
+  buf->xattr.flags_rc = ntohl(buf->xattr.flags_rc);
 
   return 0;
 }

--- a/message.h
+++ b/message.h
@@ -64,6 +64,20 @@ struct fakestat {
 #pragma pack()
 #endif
 
+#define MAX_IPC_BUFFER_SIZE 256
+
+#if __SUNPRO_C
+#pragma pack(4)
+#endif
+struct fakexattr {
+	uint32_t   buffersize;
+	char       buf[MAX_IPC_BUFFER_SIZE];
+	int32_t    flags_rc; /* flags from setxattr. Return code on round trip */
+} FAKEROOT_ATTR(packed);
+#if __SUNPRO_C
+#pragma pack()
+#endif
+
 #if __SUNPRO_C
 #pragma pack(4)
 #endif
@@ -77,6 +91,7 @@ struct fake_msg {
 	int serial;
 #endif
 	struct fakestat st;
+	struct fakexattr xattr;
 	uint32_t        remote;
 } FAKEROOT_ATTR(packed);
 #if __SUNPRO_C

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -10,7 +10,8 @@ TESTS =						\
   t.option					\
   t.tar						\
   t.touchinstall				\
-  t.truereturn
+  t.truereturn \
+  t.xattr
 
 suffix =
 TESTS_ENVIRONMENT =				\

--- a/test/t.xattr
+++ b/test/t.xattr
@@ -1,0 +1,11 @@
+#!/bin/sh
+. ./defs || exit 1
+
+mkdir $tmp
+touch $tmp/foo
+# fakeroot mangles spaces unless the getopt utility is the GNU version
+echo "setcap cap_net_raw+ep $tmp/foo; getcap $tmp/foo" >$tmp/sh
+run_fakeroot -- \
+  ${posixshell} $tmp/sh >$tmp/out
+cat $tmp/out
+grep "^$tmp/foo = cap_net_raw+ep" $tmp/out

--- a/wrapfunc.inp
+++ b/wrapfunc.inp
@@ -145,6 +145,19 @@ setfsgid;gid_t;(gid_t fsgid);(fsgid)
 #endif /* HAVE_SETFSGID */
 initgroups;int;(const char *user, INITGROUPS_SECOND_ARG group);(user, group)
 setgroups;int;(SETGROUPS_SIZE_TYPE size, const gid_t *list);(size, list)
+capset;int;(cap_user_header_t hdrp, const cap_user_data_t datap);(hdrp, datap)
+listxattr; ssize_t;(const char *path, char *list, size_t size);(path, list, size)
+llistxattr; ssize_t;(const char *path, char *list, size_t size);(path, list, size)
+flistxattr; ssize_t;(int fd, char *list, size_t size);(fd, list, size)
+getxattr;ssize_t;(const char *path, const char *name, void *value, size_t size);(path, name, value, size)
+lgetxattr;ssize_t;(const char *path, const char *name, void *value, size_t size);(path, name, value, size)
+fgetxattr;ssize_t;(int fd, const char *name, void *value, size_t size);(fd, name, value, size)
+setxattr;ssize_t;(const char *path, const char *name, void *value, size_t size, int flags);(path, name, value, size, flags)
+lsetxattr;ssize_t;(const char *path, const char *name, void *value, size_t size, int flags);(path, name, value, size, flags)
+fsetxattr;ssize_t;(int fd, const char *name, void *value, size_t size, int flags);(fd, name, value, size, flags)
+removexattr;ssize_t;(const char *path, const char *name);(path, name)
+lremovexattr;ssize_t;(const char *path, const char *name);(path, name)
+fremovexattr;ssize_t;(int fd, const char *name);(fd, name)
 
 #ifdef HAVE_FSTATAT
 #ifdef HAVE_FCHMODAT


### PR DESCRIPTION
This change adds support for setting extended attributes in a fakeroot environment.
The following syscalls are wrapped: {,l,f}{set,get,list,remove}xattr()
capset(2) is wrapped to make the userspace tool setcap(8) work.
Using setfattr(1) directly works too.

I tested the changes on linux i386 and amd64.

This change would be useful for packaging:
  No more need to set xattr/capabilites in postinst.

Limitations:

Currently the ipc from libfakeroot.so to faked only deals with stat information.
I extended the message format to pass a fixed size (256byte) buffer around.
Extended attributes which need more space would generate an ERANGE error.

I did not test on platform other than linux or x86.

Best Regards,
Torsten Schmutzler
