### PR TITLE
Cleanup ifdefs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,11 @@ ACLOCAL_AMFLAGS = -I build-aux
 SUBDIRS=scripts doc test
 
 noinst_LTLIBRARIES = libcommunicate.la libmacosx.la
-libcommunicate_la_SOURCES = communicate.c
+if FAKEROOT_FAKENET
+libcommunicate_la_SOURCES = communicate.c communicate-tcp.c
+else !FAKEROOT_FAKENET
+libcommunicate_la_SOURCES = communicate.c communicate-sysv.c
+endif !FAKEROOT_FAKENET
 
 libmacosx_la_SOURCES = libfakeroot_inode64.c libfakeroot_unix2003.c patchattr.h
 

--- a/communicate-sysv.c
+++ b/communicate-sysv.c
@@ -1,0 +1,226 @@
+/*
+  Copyright Ⓒ 1997, 1998, 1999, 2000, 2001  joost witteveen
+  Copyright Ⓒ 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009  Clint Adams
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+ This file contains the code (wrapper functions) that gets linked with
+ the programes run from inside fakeroot. These programes then communicate
+ with the fakeroot daemon, that keeps information about the "fake"
+ ownerships etc. of the files etc.
+
+ */
+
+#ifdef __APPLE__
+/*
+   In this file, we want 'struct stat' to have a 32-bit 'ino_t'.
+   We use 'struct stat64' when we need a 64-bit 'ino_t'.
+*/
+#define _DARWIN_NO_64_BIT_INODE
+#endif
+
+#include "communicate.h"
+#include <errno.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ipc.h>
+#include <sys/msg.h>
+#include <sys/sem.h>
+
+int msg_snd=-1;
+int msg_get=-1;
+int sem_id=-1;
+
+void semaphore_up(){
+  struct sembuf op;
+  if(sem_id==-1)
+    sem_id=semget(get_ipc_key(0)+2,1,IPC_CREAT|0600);
+  op.sem_num=0;
+  op.sem_op=-1;
+  op.sem_flg=SEM_UNDO;
+  init_get_msg();
+  while (1) {
+    if (semop(sem_id,&op,1)) {
+      if (errno != EINTR) {
+	perror("semop(1): encountered an error");
+        exit(1);
+      }
+    } else {
+      break;
+    }
+  }
+}
+
+void semaphore_down(){
+  struct sembuf op;
+  if(sem_id==-1)
+    sem_id=semget(get_ipc_key(0)+2,1,IPC_CREAT|0600);
+  op.sem_num=0;
+  op.sem_op=1;
+  op.sem_flg=SEM_UNDO;
+  while (1) {
+    if (semop(sem_id,&op,1)) {
+      if (errno != EINTR) {
+        perror("semop(2): encountered an error");
+        exit(1);
+      }
+    } else {
+      break;
+    }
+  }
+}
+
+void send_fakem(const struct fake_msg *buf)
+{
+  int r;
+
+  if(init_get_msg()!=-1){
+    ((struct fake_msg *)buf)->mtype=1;
+    r=msgsnd(msg_snd, (struct fake_msg *)buf,
+	     sizeof(*buf)-sizeof(buf->mtype), 0);
+    if(r==-1)
+      perror("libfakeroot, when sending message");
+  }
+}
+
+void send_get_fakem(struct fake_msg *buf)
+{
+  /*
+  send and get a struct fakestat from the daemon.
+  We have to use serial/pid numbers in addidtion to
+     the semaphore locking, to prevent the following:
+
+  Client 1 locks and sends a stat() request to deamon.
+  meantime, client 2 tries to up the semaphore too, but blocks.
+  While client 1 is waiting, it recieves a KILL signal, and dies.
+  SysV semaphores can eighter be automatically cleaned up when
+  a client dies, or they can stay in place. We have to use the
+  cleanup version, as otherwise client 2 will block forever.
+  So, the semaphore is cleaned up when client 1 recieves the KILL signal.
+  Now, client 1 falls through the semaphore_up, and
+  sends a stat() request to the daemon --  it will now recieve
+  the answer intended for client 1, and hell breaks lose (yes,
+  this has actually happened, and yes, it was hell (to debug)).
+
+  I realise that I may well do away with the semaphore stuff,
+  if I put the serial/pid numbers in the mtype field. But I cannot
+  store both PID and serial in mtype (just 32 bits on Linux). So
+  there will always be some (small) chance it will go wrong.
+  */
+
+  int l;
+  pid_t pid;
+  static int serial=0;
+
+  if(init_get_msg()!=-1){
+    pid=getpid();
+    semaphore_up();
+    serial++;
+    buf->serial=serial;
+    buf->pid=pid;
+    send_fakem(buf);
+
+    do
+      l=msgrcv(msg_get,
+               (struct my_msgbuf*)buf,
+               sizeof(*buf)-sizeof(buf->mtype),0,0);
+    while((buf->serial!=serial)||buf->pid!=pid);
+
+    semaphore_down();
+
+    /*
+    (nah, may be wrong, due to allignment)
+
+    if(l!=sizeof(*buf)-sizeof(buf->mtype))
+    printf("libfakeroot/fakeroot, internal bug!! get_fake: length=%i != l=%i",
+    sizeof(*buf)-sizeof(buf->mtype),l);
+    */
+
+  }
+}
+
+key_t get_ipc_key(key_t new_key)
+{
+  const char *s;
+  static key_t key=-1;
+
+  if(key==-1){
+    if(new_key!=0)
+      key=new_key;
+    else if((s=env_var_set(FAKEROOTKEY_ENV)))
+      key=atoi(s);
+    else
+      key=0;
+  };
+  return key;
+}
+
+
+int init_get_msg(){
+  /* a msgget call generates a fstat() call. As fstat() is wrapped,
+     that call will in turn call semaphore_up(). So, before
+     the semaphores are setup, we should make sure we already have
+     the msg_get and msg_set id.
+     This is why semaphore_up() calls this function.*/
+  static int done=0;
+  key_t key;
+
+  if((!done)&&(msg_get==-1)){
+    key=get_ipc_key(0);
+    if(key){
+      msg_snd=msgget(get_ipc_key(0),IPC_CREAT|00600);
+      msg_get=msgget(get_ipc_key(0)+1,IPC_CREAT|00600);
+    }
+    else{
+      msg_get=-1;
+      msg_snd=-1;
+    }
+    done=1;
+  }
+  return msg_snd;
+}
+
+/* fake_get_owner() allows a process which has not set LD_PRELOAD to query
+   the fake ownership etc. of files.  That process needs to know the key
+   in use by faked - faked prints this at startup. */
+int fake_get_owner(int is_lstat, const char *key, const char *path,
+                  uid_t *uid, gid_t *gid, mode_t *mode){
+  struct stat st;
+  int i;
+
+  if (!key || !strlen(key))
+    return 0;
+
+  /* Do the stat or lstat */
+  i = (is_lstat ? lstat(path, &st) : stat(path, &st));
+  if (i < 0)
+    return i;
+
+  /* Now pass it to faked */
+  get_ipc_key(atoi(key));
+#ifndef STUPID_ALPHA_HACK
+  send_get_stat(&st);
+#else
+  send_get_stat(&st, _STAT_VER);
+#endif
+
+  /* Return the values inside the pointers */
+  if (uid)
+    *uid = st.st_uid;
+  if (gid)
+    *gid = st.st_gid;
+  if (mode)
+    *mode = st.st_mode;
+
+  return 0;
+}

--- a/communicate-tcp.c
+++ b/communicate-tcp.c
@@ -1,0 +1,253 @@
+/*
+  Copyright Ⓒ 1997, 1998, 1999, 2000, 2001  joost witteveen
+  Copyright Ⓒ 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009  Clint Adams
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+ This file contains the code (wrapper functions) that gets linked with
+ the programes run from inside fakeroot. These programes then communicate
+ with the fakeroot daemon, that keeps information about the "fake"
+ ownerships etc. of the files etc.
+
+ */
+
+#ifdef __APPLE__
+/*
+   In this file, we want 'struct stat' to have a 32-bit 'ino_t'.
+   We use 'struct stat64' when we need a 64-bit 'ino_t'.
+*/
+#define _DARWIN_NO_64_BIT_INODE
+#endif
+
+#include "communicate.h"
+#include <dlfcn.h>
+#include <stdio.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <netdb.h>
+#include <pthread.h>
+#ifdef HAVE_ENDIAN_H
+# include <endian.h>
+#endif
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdarg.h>
+#ifdef HAVE_SYS_SOCKET_H
+# include <sys/socket.h>
+#endif
+
+#ifdef STUPID_ALPHA_HACK
+#include "stats.h"
+#endif
+
+#ifndef _UTSNAME_LENGTH
+/* for LINUX libc5 */
+#  define _UTSNAME_LENGTH _SYS_NMLN
+#endif
+
+volatile int comm_sd = -1;
+static pthread_mutex_t comm_sd_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static void fail(const char *msg)
+{
+  if (errno > 0)
+    fprintf(stderr, "libfakeroot: %s: %s\n", msg, strerror(errno));
+  else
+    fprintf(stderr, "libfakeroot: %s\n", msg);
+
+  exit(1);
+}
+
+static struct sockaddr *get_addr(void)
+{
+  static struct sockaddr_in addr = { 0, 0, { 0 } };
+
+  if (!addr.sin_port) {
+    char *str;
+    int port;
+
+    str = (char *) env_var_set(FAKEROOTKEY_ENV);
+    if (!str) {
+      errno = 0;
+      fail("FAKEROOTKEY not defined in environment");
+    }
+
+    port = atoi(str);
+    if (port <= 0 || port >= 65536) {
+      errno = 0;
+      fail("invalid port number in FAKEROOTKEY");
+    }
+
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port);
+  }
+
+  return (struct sockaddr *) &addr;
+}
+
+static void open_comm_sd(void)
+{
+  if (comm_sd >= 0)
+    return;
+
+  comm_sd = socket(PF_INET, SOCK_STREAM, 0);
+  if (comm_sd < 0)
+    fail("socket");
+
+  if (fcntl(comm_sd, F_SETFD, FD_CLOEXEC) < 0)
+    fail("fcntl(F_SETFD, FD_CLOEXEC)");
+
+  while (1) {
+    if (connect(comm_sd, get_addr(), sizeof (struct sockaddr_in)) < 0) {
+      if (errno != EINTR)
+        fail("connect");
+    } else
+      break;
+  }
+}
+
+void lock_comm_sd(void)
+{
+  pthread_mutex_lock(&comm_sd_mutex);
+}
+
+void unlock_comm_sd(void)
+{
+  pthread_mutex_unlock(&comm_sd_mutex);
+}
+
+
+static size_t write_all(int fd,const void*buf,size_t count) {
+  ssize_t rc,remaining=count;
+  while(remaining>0) {
+	  rc= write(fd, buf+(count-remaining), remaining);
+	  if(rc<=0) {
+		  if(remaining==count) return rc;
+		  else fail("partial write");
+	  } else {
+		  remaining-=rc;
+	  }
+  }
+  return count-remaining;
+}
+
+static size_t read_all(int fd,void *buf,size_t count) {
+  ssize_t rc,remaining=count;
+  while(remaining>0) {
+	  rc = read(fd,buf+(count-remaining),remaining);
+	  if(rc<=0) {
+		  if(remaining==count) return rc;
+		  else fail("partial read");
+	  } else {
+		  remaining-=rc;
+	  }
+  }
+  return count-remaining;
+}
+
+static void send_fakem_nr(const struct fake_msg *buf)
+{
+  struct fake_msg fm;
+
+  fm.id = htonl(buf->id);
+  fm.st.uid = htonl(buf->st.uid);
+  fm.st.gid = htonl(buf->st.gid);
+  fm.st.ino = htonll(buf->st.ino);
+  fm.st.dev = htonll(buf->st.dev);
+  fm.st.rdev = htonll(buf->st.rdev);
+  fm.st.mode = htonl(buf->st.mode);
+  fm.st.nlink = htonl(buf->st.nlink);
+  fm.remote = htonl(0);
+  fm.xattr.buffersize = htonl(buf->xattr.buffersize);
+  fm.xattr.flags_rc = htonl(buf->xattr.flags_rc);
+  memcpy(fm.xattr.buf, buf->xattr.buf, MAX_IPC_BUFFER_SIZE);
+
+  while (1) {
+    ssize_t len;
+
+    len = write_all(comm_sd, &fm, sizeof (fm));
+    if (len > 0)
+      break;
+
+    if (len == 0) {
+      errno = 0;
+      fail("write: socket is closed");
+    }
+
+    if (errno == EINTR)
+      continue;
+
+    fail("write");
+  }
+}
+
+void send_fakem(const struct fake_msg *buf)
+{
+  lock_comm_sd();
+
+  open_comm_sd();
+  send_fakem_nr(buf);
+
+  unlock_comm_sd();
+}
+
+static void get_fakem_nr(struct fake_msg *buf)
+{
+  while (1) {
+    ssize_t len;
+
+    len = read_all(comm_sd, buf, sizeof (struct fake_msg));
+    if (len > 0)
+      break;
+    if (len == 0) {
+      errno = 0;
+      fail("read: socket is closed");
+    }
+    if (errno == EINTR)
+      continue;
+   fail("read");
+  }
+
+  buf->id = ntohl(buf->id);
+  buf->st.uid = ntohl(buf->st.uid);
+  buf->st.gid = ntohl(buf->st.gid);
+  buf->st.ino = ntohll(buf->st.ino);
+  buf->st.dev = ntohll(buf->st.dev);
+  buf->st.rdev = ntohll(buf->st.rdev);
+  buf->st.mode = ntohl(buf->st.mode);
+  buf->st.nlink = ntohl(buf->st.nlink);
+  buf->remote = ntohl(buf->remote);
+  buf->xattr.buffersize = ntohl(buf->xattr.buffersize);
+  buf->xattr.flags_rc = ntohl(buf->xattr.flags_rc);
+}
+
+void send_get_fakem(struct fake_msg *buf)
+{
+  lock_comm_sd();
+
+  open_comm_sd();
+  send_fakem_nr(buf);
+  get_fakem_nr(buf);
+
+  unlock_comm_sd();
+}
+
+/* Calls to init_get_msg are needed for the sysv transport.  TCP doesn't need
+ * this so this is a noop */
+int init_get_msg(){
+  return 0;
+}
+

--- a/communicate.c
+++ b/communicate.c
@@ -61,11 +61,9 @@ const char *env_var_set(const char *env){
     return NULL;
 }
 
-void cpyfakemstat(struct fake_msg *f, const struct stat *st
-#ifdef STUPID_ALPHA_HACK
-		, int ver
-#endif
-		){
+void cpyfakemstat(struct fake_msg *f,
+                  const struct stat *st
+                  ALPHA_HACK_VERSION_PARAM){
 
 #ifndef STUPID_ALPHA_HACK
   f->st.mode =st->st_mode;
@@ -85,7 +83,7 @@ void cpyfakemstat(struct fake_msg *f, const struct stat *st
 
   f->st.nlink=st->st_nlink;
 #else
-  switch(ver) {
+  switch(alpha_hack_ver) {
 	  case _STAT_VER_KERNEL:
   f->st.mode  = ((struct fakeroot_kernel_stat *)st)->st_mode;
   f->st.ino   = ((struct fakeroot_kernel_stat *)st)->st_ino;
@@ -126,11 +124,9 @@ void cpyfakemstat(struct fake_msg *f, const struct stat *st
 #endif
 }
 
-void cpystatfakem(struct stat *st, const struct fake_msg *f
-#ifdef STUPID_ALPHA_HACK
-		, int ver
-#endif
-		){
+void cpystatfakem(struct stat *st,
+                  const struct fake_msg *f
+                  ALPHA_HACK_VERSION_PARAM){
 #ifndef STUPID_ALPHA_HACK
   st->st_mode =f->st.mode;
   st->st_ino  =f->st.ino ;
@@ -142,7 +138,7 @@ void cpystatfakem(struct stat *st, const struct fake_msg *f
      this one better! */
   /*  st->st_nlink=f->st.nlink;*/
 #else
-  switch(ver) {
+  switch(alpha_hack_ver) {
 	  case _STAT_VER_KERNEL:
   ((struct fakeroot_kernel_stat *)st)->st_mode = f->st.mode;
   ((struct fakeroot_kernel_stat *)st)->st_ino  = f->st.ino;
@@ -183,10 +179,7 @@ void cpystatfakem(struct stat *st, const struct fake_msg *f
 
 void cpyfakemstat64(struct fake_msg *f,
                  const struct stat64 *st
-#ifdef STUPID_ALPHA_HACK
-                 , int ver
-#endif
-                 ){
+                 ALPHA_HACK_VERSION_PARAM){
 #ifndef STUPID_ALPHA_HACK
   f->st.mode =st->st_mode;
   f->st.ino  =st->st_ino ;
@@ -205,7 +198,7 @@ void cpyfakemstat64(struct fake_msg *f,
 
   f->st.nlink=st->st_nlink;
 #else
-  switch(ver) {
+  switch(alpha_hack_ver) {
 	  case _STAT_VER_KERNEL:
   f->st.mode  = ((struct fakeroot_kernel_stat *)st)->st_mode;
   f->st.ino   = ((struct fakeroot_kernel_stat *)st)->st_ino;
@@ -247,10 +240,7 @@ void cpyfakemstat64(struct fake_msg *f,
 }
 void cpystat64fakem(struct stat64 *st,
                  const struct fake_msg *f
-#ifdef STUPID_ALPHA_HACK
-                 , int ver
-#endif
-                 ){
+                 ALPHA_HACK_VERSION_PARAM){
 #ifndef STUPID_ALPHA_HACK
   st->st_mode =f->st.mode;
   st->st_ino  =f->st.ino ;
@@ -262,7 +252,7 @@ void cpystat64fakem(struct stat64 *st,
      this one better! */
   /*  st->st_nlink=f->st.nlink;*/
 #else
-  switch(ver) {
+  switch(alpha_hack_ver) {
 	  case _STAT_VER_KERNEL:
   ((struct fakeroot_kernel_stat *)st)->st_mode = f->st.mode;
   ((struct fakeroot_kernel_stat *)st)->st_ino  = f->st.ino;
@@ -359,19 +349,12 @@ void stat32from64(struct stat *s32, const struct stat64 *s64)
 
 void send_stat(const struct stat *st,
 	       func_id_t f
-#ifdef STUPID_ALPHA_HACK
-	       , int ver
-#endif
-	       ){
+	       ALPHA_HACK_VERSION_PARAM){
   struct fake_msg buf;
 
   if(init_get_msg()!=-1)
   {
-#ifndef STUPID_ALPHA_HACK
-    cpyfakemstat(&buf,st);
-#else
-    cpyfakemstat(&buf,st,ver);
-#endif
+    cpyfakemstat(&buf,st ALPHA_HACK_VERSION);
     buf.id=f;
     send_fakem(&buf);
   }
@@ -380,19 +363,12 @@ void send_stat(const struct stat *st,
 #ifdef STAT64_SUPPORT
 void send_stat64(const struct stat64 *st,
                  func_id_t f
-#ifdef STUPID_ALPHA_HACK
-                 , int ver
-#endif
-                 ){
+                 ALPHA_HACK_VERSION_PARAM){
   struct fake_msg buf;
 
   if(init_get_msg()!=-1)
   {
-#ifndef STUPID_ALPHA_HACK
-    cpyfakemstat64(&buf,st);
-#else
-    cpyfakemstat64(&buf,st,ver);
-#endif
+    cpyfakemstat64(&buf,st ALPHA_HACK_VERSION);
     buf.id=f;
     send_fakem(&buf);
   }
@@ -400,36 +376,22 @@ void send_stat64(const struct stat64 *st,
 #endif /* STAT64_SUPPORT */
 
 void send_get_stat(struct stat *st
-#ifdef STUPID_ALPHA_HACK
-		, int ver
-#endif
-		){
+                   ALPHA_HACK_VERSION_PARAM){
   struct fake_msg buf;
 
   if(init_get_msg()!=-1)
   {
-#ifndef STUPID_ALPHA_HACK
-    cpyfakemstat(&buf,st);
-#else
-    cpyfakemstat(&buf,st,ver);
-#endif
+    cpyfakemstat(&buf,st ALPHA_HACK_VERSION);
 
     buf.id=stat_func;
     send_get_fakem(&buf);
-#ifndef STUPID_ALPHA_HACK
-    cpystatfakem(st,&buf);
-#else
-    cpystatfakem(st,&buf,ver);
-#endif
+    cpystatfakem(st,&buf ALPHA_HACK_VERSION);
   }
 }
 
 void send_get_xattr(struct stat *st
 		, xattr_args *xattr
-#ifdef STUPID_ALPHA_HACK
-		, int ver
-#endif
-		){
+		ALPHA_HACK_VERSION_PARAM){
   struct fake_msg buf;
   size_t in_size;
   size_t name_size;
@@ -437,11 +399,7 @@ void send_get_xattr(struct stat *st
 
   if(init_get_msg()!=-1)
   {
-#ifndef STUPID_ALPHA_HACK
-    cpyfakemstat(&buf,st);
-#else
-    cpyfakemstat(&buf,st,ver);
-#endif
+    cpyfakemstat(&buf,st ALPHA_HACK_VERSION);
     in_size = xattr->size;
     total_size = (xattr->func == setxattr_func) ? (in_size) : 0;
     if (xattr->name)
@@ -481,37 +439,23 @@ void send_get_xattr(struct stat *st
 
 #ifdef STAT64_SUPPORT
 void send_get_stat64(struct stat64 *st
-#ifdef STUPID_ALPHA_HACK
-                     , int ver
-#endif
-                    )
+                     ALPHA_HACK_VERSION_PARAM)
 {
   struct fake_msg buf;
 
   if(init_get_msg()!=-1)
   {
-#ifndef STUPID_ALPHA_HACK
-    cpyfakemstat64(&buf,st);
-#else
-    cpyfakemstat64(&buf,st,ver);
-#endif
+    cpyfakemstat64(&buf,st ALPHA_HACK_VERSION);
 
     buf.id=stat_func;
     send_get_fakem(&buf);
-#ifndef STUPID_ALPHA_HACK
-    cpystat64fakem(st,&buf);
-#else
-    cpystat64fakem(st,&buf,ver);
-#endif
+    cpystat64fakem(st,&buf ALPHA_HACK_VERSION);
   }
 }
 
 void send_get_xattr64(struct stat64 *st
 		, xattr_args *xattr
-#ifdef STUPID_ALPHA_HACK
-		, int ver
-#endif
-		){
+		ALPHA_HACK_VERSION_PARAM){
   struct fake_msg buf;
   size_t in_size;
   size_t name_size;
@@ -519,11 +463,7 @@ void send_get_xattr64(struct stat64 *st
 
   if(init_get_msg()!=-1)
   {
-#ifndef STUPID_ALPHA_HACK
-    cpyfakemstat64(&buf,st);
-#else
-    cpyfakemstat64(&buf,st,ver);
-#endif
+    cpyfakemstat64(&buf,st ALPHA_HACK_VERSION);
     in_size = xattr->size;
     total_size = (xattr->func == setxattr_func) ? (in_size) : 0;
     if (xattr->name)

--- a/communicate.c
+++ b/communicate.c
@@ -30,19 +30,6 @@
 #include "communicate.h"
 #include <dlfcn.h>
 #include <stdio.h>
-#ifndef FAKEROOT_FAKENET
-# include <sys/ipc.h>
-# include <sys/msg.h>
-# include <sys/sem.h>
-#else /* FAKEROOT_FAKENET */
-# include <netinet/in.h>
-# include <netinet/tcp.h>
-# include <netdb.h>
-# include <pthread.h>
-# ifdef HAVE_ENDIAN_H
-#  include <endian.h>
-# endif
-#endif /* FAKEROOT_FAKENET */
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
@@ -62,29 +49,6 @@
 /* for LINUX libc5 */
 #  define _UTSNAME_LENGTH _SYS_NMLN
 #endif
-
-
-#ifndef FAKEROOT_FAKENET
-int msg_snd=-1;
-int msg_get=-1;
-int sem_id=-1;
-#else /* FAKEROOT_FAKENET */
-volatile int comm_sd = -1;
-static pthread_mutex_t comm_sd_mutex = PTHREAD_MUTEX_INITIALIZER;
-#endif /* FAKEROOT_FAKENET */
-
-
-#ifdef FAKEROOT_FAKENET
-static void fail(const char *msg)
-{
-  if (errno > 0)
-    fprintf(stderr, "libfakeroot: %s: %s\n", msg, strerror(errno));
-  else
-    fprintf(stderr, "libfakeroot: %s\n", msg);
-
-  exit(1);
-}
-#endif /* FAKEROOT_FAKENET */
 
 const char *env_var_set(const char *env){
   const char *s;
@@ -393,301 +357,6 @@ void stat32from64(struct stat *s32, const struct stat64 *s64)
 
 #endif
 
-#ifndef FAKEROOT_FAKENET
-
-void semaphore_up(){
-  struct sembuf op;
-  if(sem_id==-1)
-    sem_id=semget(get_ipc_key(0)+2,1,IPC_CREAT|0600);
-  op.sem_num=0;
-  op.sem_op=-1;
-  op.sem_flg=SEM_UNDO;
-  init_get_msg();
-  while (1) {
-    if (semop(sem_id,&op,1)) {
-      if (errno != EINTR) {
-	perror("semop(1): encountered an error");
-        exit(1);
-      }
-    } else {
-      break;
-    }
-  }
-}
-
-void semaphore_down(){
-  struct sembuf op;
-  if(sem_id==-1)
-    sem_id=semget(get_ipc_key(0)+2,1,IPC_CREAT|0600);
-  op.sem_num=0;
-  op.sem_op=1;
-  op.sem_flg=SEM_UNDO;
-  while (1) {
-    if (semop(sem_id,&op,1)) {
-      if (errno != EINTR) {
-        perror("semop(2): encountered an error");
-        exit(1);
-      }
-    } else {
-      break;
-    }
-  }
-}
-
-#else /* FAKEROOT_FAKENET */
-
-static struct sockaddr *get_addr(void)
-{
-  static struct sockaddr_in addr = { 0, 0, { 0 } };
-
-  if (!addr.sin_port) {
-    char *str;
-    int port;
-
-    str = (char *) env_var_set(FAKEROOTKEY_ENV);
-    if (!str) {
-      errno = 0;
-      fail("FAKEROOTKEY not defined in environment");
-    }
-
-    port = atoi(str);
-    if (port <= 0 || port >= 65536) {
-      errno = 0;
-      fail("invalid port number in FAKEROOTKEY");
-    }
-
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    addr.sin_port = htons(port);
-  }
-
-  return (struct sockaddr *) &addr;
-}
-
-static void open_comm_sd(void)
-{
-  if (comm_sd >= 0)
-    return;
-
-  comm_sd = socket(PF_INET, SOCK_STREAM, 0);
-  if (comm_sd < 0)
-    fail("socket");
-
-  if (fcntl(comm_sd, F_SETFD, FD_CLOEXEC) < 0)
-    fail("fcntl(F_SETFD, FD_CLOEXEC)");
-
-  while (1) {
-    if (connect(comm_sd, get_addr(), sizeof (struct sockaddr_in)) < 0) {
-      if (errno != EINTR)
-        fail("connect");
-    } else
-      break;
-  }
-}
-
-void lock_comm_sd(void)
-{
-  pthread_mutex_lock(&comm_sd_mutex);
-}
-
-void unlock_comm_sd(void)
-{
-  pthread_mutex_unlock(&comm_sd_mutex);
-}
-
-#endif /* FAKEROOT_FAKENET */
-
-#ifndef FAKEROOT_FAKENET
-
-void send_fakem(const struct fake_msg *buf)
-{
-  int r;
-
-  if(init_get_msg()!=-1){
-    ((struct fake_msg *)buf)->mtype=1;
-    r=msgsnd(msg_snd, (struct fake_msg *)buf,
-	     sizeof(*buf)-sizeof(buf->mtype), 0);
-    if(r==-1)
-      perror("libfakeroot, when sending message");
-  }
-}
-
-void send_get_fakem(struct fake_msg *buf)
-{
-  /*
-  send and get a struct fakestat from the daemon.
-  We have to use serial/pid numbers in addidtion to
-     the semaphore locking, to prevent the following:
-
-  Client 1 locks and sends a stat() request to deamon.
-  meantime, client 2 tries to up the semaphore too, but blocks.
-  While client 1 is waiting, it recieves a KILL signal, and dies.
-  SysV semaphores can eighter be automatically cleaned up when
-  a client dies, or they can stay in place. We have to use the
-  cleanup version, as otherwise client 2 will block forever.
-  So, the semaphore is cleaned up when client 1 recieves the KILL signal.
-  Now, client 1 falls through the semaphore_up, and
-  sends a stat() request to the daemon --  it will now recieve
-  the answer intended for client 1, and hell breaks lose (yes,
-  this has actually happened, and yes, it was hell (to debug)).
-
-  I realise that I may well do away with the semaphore stuff,
-  if I put the serial/pid numbers in the mtype field. But I cannot
-  store both PID and serial in mtype (just 32 bits on Linux). So
-  there will always be some (small) chance it will go wrong.
-  */
-
-  int l;
-  pid_t pid;
-  static int serial=0;
-
-  if(init_get_msg()!=-1){
-    pid=getpid();
-    semaphore_up();
-    serial++;
-    buf->serial=serial;
-    buf->pid=pid;
-    send_fakem(buf);
-
-    do
-      l=msgrcv(msg_get,
-               (struct my_msgbuf*)buf,
-               sizeof(*buf)-sizeof(buf->mtype),0,0);
-    while((buf->serial!=serial)||buf->pid!=pid);
-
-    semaphore_down();
-
-    /*
-    (nah, may be wrong, due to allignment)
-
-    if(l!=sizeof(*buf)-sizeof(buf->mtype))
-    printf("libfakeroot/fakeroot, internal bug!! get_fake: length=%i != l=%i",
-    sizeof(*buf)-sizeof(buf->mtype),l);
-    */
-
-  }
-}
-
-#else /* FAKEROOT_FAKENET */
-
-
-static size_t write_all(int fd,const void*buf,size_t count) {
-  ssize_t rc,remaining=count;
-  while(remaining>0) {
-	  rc= write(fd, buf+(count-remaining), remaining);
-	  if(rc<=0) {
-		  if(remaining==count) return rc;
-		  else fail("partial write");
-	  } else {
-		  remaining-=rc;
-	  }
-  }
-  return count-remaining;
-}
-
-static size_t read_all(int fd,void *buf,size_t count) {
-  ssize_t rc,remaining=count;
-  while(remaining>0) {
-	  rc = read(fd,buf+(count-remaining),remaining);
-	  if(rc<=0) {
-		  if(remaining==count) return rc;
-		  else fail("partial read");
-	  } else {
-		  remaining-=rc;
-	  }
-  }
-  return count-remaining;
-}
-
-static void send_fakem_nr(const struct fake_msg *buf)
-{
-  struct fake_msg fm;
-
-  fm.id = htonl(buf->id);
-  fm.st.uid = htonl(buf->st.uid);
-  fm.st.gid = htonl(buf->st.gid);
-  fm.st.ino = htonll(buf->st.ino);
-  fm.st.dev = htonll(buf->st.dev);
-  fm.st.rdev = htonll(buf->st.rdev);
-  fm.st.mode = htonl(buf->st.mode);
-  fm.st.nlink = htonl(buf->st.nlink);
-  fm.remote = htonl(0);
-  fm.xattr.buffersize = htonl(buf->xattr.buffersize);
-  fm.xattr.flags_rc = htonl(buf->xattr.flags_rc);
-  memcpy(fm.xattr.buf, buf->xattr.buf, MAX_IPC_BUFFER_SIZE);
-
-  while (1) {
-    ssize_t len;
-
-    len = write_all(comm_sd, &fm, sizeof (fm));
-    if (len > 0)
-      break;
-
-    if (len == 0) {
-      errno = 0;
-      fail("write: socket is closed");
-    }
-
-    if (errno == EINTR)
-      continue;
-
-    fail("write");
-  }
-}
-
-void send_fakem(const struct fake_msg *buf)
-{
-  lock_comm_sd();
-
-  open_comm_sd();
-  send_fakem_nr(buf);
-
-  unlock_comm_sd();
-}
-
-static void get_fakem_nr(struct fake_msg *buf)
-{
-  while (1) {
-    ssize_t len;
-
-    len = read_all(comm_sd, buf, sizeof (struct fake_msg));
-    if (len > 0)
-      break;
-    if (len == 0) {
-      errno = 0;
-      fail("read: socket is closed");
-    }
-    if (errno == EINTR)
-      continue;
-   fail("read");
-  }
-
-  buf->id = ntohl(buf->id);
-  buf->st.uid = ntohl(buf->st.uid);
-  buf->st.gid = ntohl(buf->st.gid);
-  buf->st.ino = ntohll(buf->st.ino);
-  buf->st.dev = ntohll(buf->st.dev);
-  buf->st.rdev = ntohll(buf->st.rdev);
-  buf->st.mode = ntohl(buf->st.mode);
-  buf->st.nlink = ntohl(buf->st.nlink);
-  buf->remote = ntohl(buf->remote);
-  buf->xattr.buffersize = ntohl(buf->xattr.buffersize);
-  buf->xattr.flags_rc = ntohl(buf->xattr.flags_rc);
-}
-
-void send_get_fakem(struct fake_msg *buf)
-{
-  lock_comm_sd();
-
-  open_comm_sd();
-  send_fakem_nr(buf);
-  get_fakem_nr(buf);
-
-  unlock_comm_sd();
-}
-
-#endif /* FAKEROOT_FAKENET */
-
 void send_stat(const struct stat *st,
 	       func_id_t f
 #ifdef STUPID_ALPHA_HACK
@@ -696,9 +365,7 @@ void send_stat(const struct stat *st,
 	       ){
   struct fake_msg buf;
 
-#ifndef FAKEROOT_FAKENET
   if(init_get_msg()!=-1)
-#endif /* ! FAKEROOT_FAKENET */
   {
 #ifndef STUPID_ALPHA_HACK
     cpyfakemstat(&buf,st);
@@ -719,9 +386,7 @@ void send_stat64(const struct stat64 *st,
                  ){
   struct fake_msg buf;
 
-#ifndef FAKEROOT_FAKENET
   if(init_get_msg()!=-1)
-#endif /* ! FAKEROOT_FAKENET */
   {
 #ifndef STUPID_ALPHA_HACK
     cpyfakemstat64(&buf,st);
@@ -741,9 +406,7 @@ void send_get_stat(struct stat *st
 		){
   struct fake_msg buf;
 
-#ifndef FAKEROOT_FAKENET
   if(init_get_msg()!=-1)
-#endif /* ! FAKEROOT_FAKENET */
   {
 #ifndef STUPID_ALPHA_HACK
     cpyfakemstat(&buf,st);
@@ -772,9 +435,7 @@ void send_get_xattr(struct stat *st
   size_t name_size;
   size_t total_size;
 
-#ifndef FAKEROOT_FAKENET
   if(init_get_msg()!=-1)
-#endif /* ! FAKEROOT_FAKENET */
   {
 #ifndef STUPID_ALPHA_HACK
     cpyfakemstat(&buf,st);
@@ -827,9 +488,7 @@ void send_get_stat64(struct stat64 *st
 {
   struct fake_msg buf;
 
-#ifndef FAKEROOT_FAKENET
   if(init_get_msg()!=-1)
-#endif /* ! FAKEROOT_FAKENET */
   {
 #ifndef STUPID_ALPHA_HACK
     cpyfakemstat64(&buf,st);
@@ -858,9 +517,7 @@ void send_get_xattr64(struct stat64 *st
   size_t name_size;
   size_t total_size;
 
-#ifndef FAKEROOT_FAKENET
   if(init_get_msg()!=-1)
-#endif /* ! FAKEROOT_FAKENET */
   {
 #ifndef STUPID_ALPHA_HACK
     cpyfakemstat64(&buf,st);
@@ -904,83 +561,3 @@ void send_get_xattr64(struct stat64 *st
   }
 }
 #endif /* STAT64_SUPPORT */
-
-#ifndef FAKEROOT_FAKENET
-
-key_t get_ipc_key(key_t new_key)
-{
-  const char *s;
-  static key_t key=-1;
-
-  if(key==-1){
-    if(new_key!=0)
-      key=new_key;
-    else if((s=env_var_set(FAKEROOTKEY_ENV)))
-      key=atoi(s);
-    else
-      key=0;
-  };
-  return key;
-}
-
-
-int init_get_msg(){
-  /* a msgget call generates a fstat() call. As fstat() is wrapped,
-     that call will in turn call semaphore_up(). So, before
-     the semaphores are setup, we should make sure we already have
-     the msg_get and msg_set id.
-     This is why semaphore_up() calls this function.*/
-  static int done=0;
-  key_t key;
-
-  if((!done)&&(msg_get==-1)){
-    key=get_ipc_key(0);
-    if(key){
-      msg_snd=msgget(get_ipc_key(0),IPC_CREAT|00600);
-      msg_get=msgget(get_ipc_key(0)+1,IPC_CREAT|00600);
-    }
-    else{
-      msg_get=-1;
-      msg_snd=-1;
-    }
-    done=1;
-  }
-  return msg_snd;
-}
-
-/* fake_get_owner() allows a process which has not set LD_PRELOAD to query
-   the fake ownership etc. of files.  That process needs to know the key
-   in use by faked - faked prints this at startup. */
-int fake_get_owner(int is_lstat, const char *key, const char *path,
-                  uid_t *uid, gid_t *gid, mode_t *mode){
-  struct stat st;
-  int i;
-
-  if (!key || !strlen(key))
-    return 0;
-
-  /* Do the stat or lstat */
-  i = (is_lstat ? lstat(path, &st) : stat(path, &st));
-  if (i < 0)
-    return i;
-
-  /* Now pass it to faked */
-  get_ipc_key(atoi(key));
-#ifndef STUPID_ALPHA_HACK
-  send_get_stat(&st);
-#else
-  send_get_stat(&st, _STAT_VER);
-#endif
-
-  /* Return the values inside the pointers */
-  if (uid)
-    *uid = st.st_uid;
-  if (gid)
-    *gid = st.st_gid;
-  if (mode)
-    *mode = st.st_mode;
-
-  return 0;
-}
-
-#endif /* ! FAKEROOT_FAKENET */

--- a/communicate.h
+++ b/communicate.h
@@ -128,6 +128,14 @@
 # define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO)/* 07777 */
 #endif
 
+#ifdef STUPID_ALPHA_HACK
+#define ALPHA_HACK_VERSION_PARAM , int alpha_hack_ver
+#define ALPHA_HACK_VERSION , alpha_hack_ver
+#else
+#define ALPHA_HACK_VERSION_PARAM
+#define ALPHA_HACK_VERSION
+#endif
+
 /* Define big enough _constant size_ types for the various types of the
    stat struct. I cannot (or rather, shouldn't) use struct stat itself
    in the communication between the fake-daemon and the client (libfake),
@@ -164,37 +172,17 @@ typedef struct {
 #include "message.h"
 
 extern const char *env_var_set(const char *env);
-#ifndef STUPID_ALPHA_HACK
-extern void send_stat(const struct stat *st, func_id_t f);
-#else
-extern void send_stat(const struct stat *st, func_id_t f,int ver);
-#endif
+extern void send_stat(const struct stat *st, func_id_t f ALPHA_HACK_VERSION_PARAM);
 extern void send_fakem(const struct fake_msg *buf);
-#ifndef STUPID_ALPHA_HACK
-extern void send_get_stat(struct stat *buf);
-#else
-extern void send_get_stat(struct stat *buf,int ver);
-#endif
-#ifndef STUPID_ALPHA_HACK
-extern void send_get_xattr(struct stat *st, xattr_args *xattr);
-#else
-extern void send_get_xattr(struct stat *st, xattr_args *xattr, int ver);
-#endif
+extern void send_get_stat(struct stat *buf ALPHA_HACK_VERSION_PARAM);
+extern void send_get_xattr(struct stat *st, xattr_args *xattr ALPHA_HACK_VERSION_PARAM);
 extern void cpyfakefake (struct fakestat *b1, const struct fakestat *b2);
-#ifndef STUPID_ALPHA_HACK
-extern void cpystatfakem(struct     stat *st, const struct fake_msg *buf);
-#else
-extern void cpystatfakem(struct     stat *st, const struct fake_msg *buf, int ver);
-#endif
+extern void cpystatfakem(struct     stat *st, const struct fake_msg *buf ALPHA_HACK_VERSION_PARAM);
 
 extern int init_get_msg();
 #ifndef FAKEROOT_FAKENET
 extern key_t get_ipc_key(key_t new_key);
-# ifndef STUPID_ALPHA_HACK
-extern void cpyfakemstat(struct fake_msg *b1, const struct stat *st);
-# else
-extern void cpyfakemstat(struct fake_msg *b1, const struct stat *st, int ver);
-# endif
+extern void cpyfakemstat(struct fake_msg *b1, const struct stat *st ALPHA_HACK_VERSION_PARAM);
 #else /* FAKEROOT_FAKENET */
 # ifdef FAKEROOT_LIBFAKEROOT
 extern volatile int comm_sd;
@@ -204,15 +192,9 @@ extern void unlock_comm_sd(void);
 #endif /* FAKEROOT_FAKENET */
 
 #ifdef STAT64_SUPPORT
-#ifndef STUPID_ALPHA_HACK
-extern void send_stat64(const struct stat64 *st, func_id_t f);
-extern void send_get_stat64(struct stat64 *buf);
-extern void send_get_xattr64(struct stat64 *st, xattr_args *xattr);
-#else
-extern void send_stat64(const struct stat64 *st, func_id_t f, int ver);
-extern void send_get_stat64(struct stat64 *buf, int ver);
-extern void send_get_xattr64(struct stat64 *st, xattr_args *xattr, int ver);
-#endif
+extern void send_stat64(const struct stat64 *st, func_id_t f ALPHA_HACK_VERSION_PARAM);
+extern void send_get_stat64(struct stat64 *buf ALPHA_HACK_VERSION_PARAM);
+extern void send_get_xattr64(struct stat64 *st, xattr_args *xattr ALPHA_HACK_VERSION_PARAM);
 extern void stat64from32(struct stat64 *s64, const struct stat *s32);
 extern void stat32from64(struct stat *s32, const struct stat64 *s64);
 #endif

--- a/communicate.h
+++ b/communicate.h
@@ -187,8 +187,8 @@ extern void cpystatfakem(struct     stat *st, const struct fake_msg *buf);
 extern void cpystatfakem(struct     stat *st, const struct fake_msg *buf, int ver);
 #endif
 
-#ifndef FAKEROOT_FAKENET
 extern int init_get_msg();
+#ifndef FAKEROOT_FAKENET
 extern key_t get_ipc_key(key_t new_key);
 # ifndef STUPID_ALPHA_HACK
 extern void cpyfakemstat(struct fake_msg *b1, const struct stat *st);
@@ -222,5 +222,7 @@ extern int msg_snd;
 extern int msg_get;
 extern int sem_id;
 #endif /* ! FAKEROOT_FAKENET */
+
+void send_get_fakem(struct fake_msg *buf);
 
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,7 @@ signal=HUP
 else
 signal=TERM
 fi
+AM_CONDITIONAL(FAKEROOT_FAKENET, test x$ac_cv_use_ipc = xtcp)
 
 AC_SUBST(signal)
 


### PR DESCRIPTION
Replacing `#ifdef`s with `#define` and build time conditionals makes the code easier to understand.
